### PR TITLE
Fix audio file 404 error for GitHub Pages deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: '/birthday',
   eslint: {
     ignoreDuringBuilds: true, // Consider setting to false for stricter production builds
   },


### PR DESCRIPTION
- Add basePath '/birthday' to next.config.mjs to handle GitHub Pages repository-based URLs
- Audio files will now load correctly from https://thethyka.github.io/birthday/birthday-song.mp3
- Fixes HTTP 404 errors when loading media resources on GitHub Pages